### PR TITLE
Update Get-SfAccount and Get-SfOpportunity functions with ID support and add URL ID extraction

### DIFF
--- a/Test/public/getsfId.test.ps1
+++ b/Test/public/getsfId.test.ps1
@@ -1,0 +1,15 @@
+function Test_sfIdFromUrl{
+
+    $urlList = @(
+        "https://github.lightning.force.com/lightning/r/Account/0010V00002Q8r78QAB/view",
+        "https://github.lightning.force.com/lightning/r/Account/0010V00002Q8r78QAB/",
+        "https://github.lightning.force.com/lightning/r/Account/0010V00002Q8r78QAB",
+        "https://github.my.salesforce.com/0010V00002Q8r78QAB"
+    )
+
+    $urlList | ForEach-Object {
+        $result = Get-SfIdFromUrl $_
+        Assert-AreEqual -Expected "0010V00002Q8r78QAB" -Presented $result.SfId
+    }
+
+}

--- a/Test/public/getsfopportunity.test.ps1
+++ b/Test/public/getsfopportunity.test.ps1
@@ -1,4 +1,3 @@
-
 function Test_GetSfOpportunity{
 
     Reset-InvokeCommandMock
@@ -44,6 +43,20 @@ function  Test_GetSfOpportunity_Live{
     Assert-NotImplemented
 }
 
+function Test_GetSfOpportunity_Id{
+    Reset-InvokeCommandMock
+
+    # Mocks
+    Mock_Database -ResetDatabase
+    Mock_Config
+    Mock_SfDataQuery_Opportunity_0065c00001SFRbYAAX
+
+    # Act with out cache
+    $result = Get-SfOpportunity -Id 0065c00001SFRbYAAX
+
+    # Assert
+    Assert-AreEqual -Expected "0065c00001SFRbYAAX" -Presented $result.Id
+}
 
 function Mock_SfDataQuery_Opportunity_0065c00001SFRbYAAX{
     [CmdletBinding()]

--- a/Test/public/getstaccount.test.ps1
+++ b/Test/public/getstaccount.test.ps1
@@ -36,6 +36,23 @@ function Test_GetSfAccount{
     Assert-AreEqual -Expected "0010V00002KIWkaQAH" -Presented $result.Id
 }
 
+function Test_GetSfAccount_Id{
+    Reset-InvokeCommandMock
+
+    # Mocks
+    Mock_Database -ResetDatabase
+    Mock_Config
+    Mock_SfDataQuery_Account_0010V00002KIWkaQAH
+
+    # Act with out cache
+    $result = Get-SfAccount -Id 0010V00002KIWkaQAH
+
+    # Assert
+    Assert-AreEqual -Expected "Hashtable" -Presented $result.GetType().BaseType.Name
+    Assert-AreEqual -Expected "0010V00002KIWkaQAH" -Presented $result.Id
+
+}
+
 function Test_GetSfAccount_Transformations{
     Reset-InvokeCommandMock
 

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -3,8 +3,8 @@
 
 ## Sample commands
 
-### Get-SfAccount
+### Get-SfUser
 
 ```powershell
-Get-SfAccount https://github.lightning.force.com/lightning/r/Account/0013o00002ZKSfaAAH/view
+Get-SfUser 0055c000009T2o8AAC
 ```

--- a/public/getsfId.ps1
+++ b/public/getsfId.ps1
@@ -1,0 +1,22 @@
+# PowerShell module to get the ID from a Service Fabric URL
+# Allow to integrate with ProjectHelper returning SfId
+
+function Get-SfIdFromUrl{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,ValueFromPipeline, Position=0)]
+        [string]$SfUrl
+    )
+
+    process{
+
+        # Extract Id from URL
+        $Id = Get-SfObjectIdFromUrl -SfUrl $SfUrl
+        
+        $ret = @{
+            SfId = $Id
+        }
+        
+        return $ret
+    }
+} Export-ModuleMember -Function Get-SfIdFromUrl

--- a/public/getsfaccount.ps1
+++ b/public/getsfaccount.ps1
@@ -1,4 +1,3 @@
-
 <#
 .SYNOPSIS
 Retrieves Salesforce Account data based on the specified Salesforce URL.
@@ -8,6 +7,16 @@ The `Get-SfAccount` function extracts the Salesforce Account ID from the provide
 
 .PARAMETER SfUrl
 The Salesforce URL of the Account object to query.
+
+.PARAMETER AdditionalAttributes
+Additional attributes to retrieve from the Salesforce Account object. This parameter accepts a comma-separated string of attribute names.
+If not specified, the function retrieves a default set of attributes.
+
+.PARAMETER Force
+A switch parameter that forces the function to retrieve the data even if it is already cached.
+
+.PARAMETER Id
+The Salesforce ID of the Account object to query. If specified, the function will use this ID instead of extracting it from the URL.
 
 .OUTPUTS
 The function returns a PowerShell object representing the queried Salesforce Account data. If the query is unsuccessful or the object is not found, the function returns `$null`.
@@ -19,6 +28,11 @@ PS> $result
 
 This example retrieves the specified attributes for the Salesforce Account object with the ID extracted from the provided URL.
 
+.EXAMPLE
+PS> Get-SfAccount -Id 0013o00002OHreEAAT
+
+This example retrieves the specified attributes for the Salesforce Account object with the specified ID.
+
 .NOTES
 The function uses the `Get-SfDataQuery` function to perform the query and the `Get-OwnerNameFromHtml` function to clean up the `Account_Owner__c` field.
 
@@ -26,17 +40,21 @@ The function uses the `Get-SfDataQuery` function to perform the query and the `G
 function Get-SfAccount{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,Position=0)][string]$SfUrl,
+        [Parameter(Position=0)][string]$SfUrl,
         [string]$AdditionalAttributes,
-        [switch]$Force
+        [switch]$Force,
+        [Parameter()][string]$Id
     )
 
-    # Extract Id from URL
-    $Id = Get-SfObjectIdFromUrl -SfUrl $SfUrl
-    $type = Get-SfObjectTypeFromUrl -SfUrl $SfUrl
-
-    if ($type -ne "Account") {
-        throw "Invalid Salesforce Object URL $SfUrl"
+    if ([string]::IsNullOrWhiteSpace($Id)){
+        
+        # Extract Id from URL
+        $Id = Get-SfObjectIdFromUrl -SfUrl $SfUrl
+        $type = Get-SfObjectTypeFromUrl -SfUrl $SfUrl
+        
+        if ($type -ne "Account") {
+            throw "Invalid Salesforce Object URL $SfUrl"
+        }
     }
 
     $attributes = @(

--- a/public/getsfopportunity.ps1
+++ b/public/getsfopportunity.ps1
@@ -1,5 +1,3 @@
-
-
 <#
 .SYNOPSIS
 Retrieves Salesforce Opportunity data based on the specified Salesforce URL.
@@ -31,17 +29,20 @@ This example retrieves the specified attributes for the Salesforce Opportunity o
 function Get-SfOpportunity{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,Position=0)][string]$SfUrl,
+        [Parameter(Position=0)][string]$SfUrl,
         [string]$AdditionalAttributes,
-        [switch]$Force
+        [switch]$Force,
+        [Parameter()][string]$Id
     )
 
-    # Extract Id from URL
-    $Id = Get-SfObjectIdFromUrl -SfUrl $SfUrl
-    $type = Get-SfObjectTypeFromUrl -SfUrl $SfUrl
-
-    if ($type -ne "Opportunity") {
-        throw "Invalid Salesforce Object URL $SfUrl"
+    if ([string]::IsNullOrWhiteSpace($Id)){
+        # Extract Id from URL
+        $Id = Get-SfObjectIdFromUrl -SfUrl $SfUrl
+        $type = Get-SfObjectTypeFromUrl -SfUrl $SfUrl
+        
+        if ($type -ne "Opportunity") {
+            throw "Invalid Salesforce Object URL $SfUrl"
+        }
     }
 
     $attributes = @(


### PR DESCRIPTION
Enhance the Get-SfAccount and Get-SfOpportunity functions to accept an ID parameter, allowing users to query directly by ID. Introduce a new function, Get-SfIdFromUrl, to extract IDs from Service Fabric URLs. Update documentation and tests accordingly.