### PR TITLE
bug: QueryData not being updated properlly

### DIFF
--- a/Test/public/getstaccount.test.ps1
+++ b/Test/public/getstaccount.test.ps1
@@ -36,6 +36,45 @@ function Test_GetSfAccount{
     Assert-AreEqual -Expected "0010V00002KIWkaQAH" -Presented $result.Id
 }
 
+function Test_GetSfAccount_cache{
+
+    Reset-InvokeCommandMock
+
+    $mockAttrib = @{account_attributes = @("Potential_Seats_Manual__c","Website","PhotoUrl")}
+
+    # Mocks
+    Mock_Database -ResetDatabase
+    Mock_Config -Config $mockAttrib
+
+    # Mock Sf call
+    $id = "0010V00002KIWkaQAH"
+    $url = "https://github.lightning.force.com/lightning/r/Account/$id/view"
+    $filename = "sfDataQuery-Account-$id-01F5F2DFDE481D1146E8D504BB935E4D.json"
+    Mock_SfDataQuery_Account_0010V00002KIWkaQAH -AdditionalAttributes $mockAttrib.account_attributes
+
+    # Arrange cache with different data
+    $result = Get-SfAccount -SfUrl $url
+    Assert-AreEqual -Expected "Spain" -Presented $result.Country_Name__c
+
+    # Arrange update cache with different data
+    $path = Get-Mock_DatabaseStore | Join-Path -ChildPath $filename
+    $mockdata = Get-Content -Path $path -Raw | ConvertFrom-Json -Depth 10 -asHashtable
+    $mockdata.Country_Name__c = "kkContry"
+    $mockdata | ConvertTo-Json -Depth 10 | Set-Content -Path $path
+
+    # Act with cache
+    $result = Get-SfAccount -SfUrl $url
+    Assert-AreEqual -Expected "kkContry" -Presented $result.Country_Name__c
+    
+    # Froce integration to update the cache
+    $result = Get-SfAccount -SfUrl $url -Force
+    Assert-AreEqual -Expected "Spain" -Presented $result.Country_Name__c
+
+    # Act with cache to get proper name again
+    $result = Get-SfAccount -SfUrl $url
+    Assert-AreEqual -Expected "Spain" -Presented $result.Country_Name__c
+}
+
 function Test_GetSfAccount_Id{
     Reset-InvokeCommandMock
 

--- a/public/sfDataQuery.ps1
+++ b/public/sfDataQuery.ps1
@@ -8,11 +8,13 @@ function Get-SfDataQuery{
         [Parameter(Mandatory)][string[]]$Attributes,
         [switch]$Force
     )
+    
+    # Get Cache Key to read or write the output
+    $cacheKey = getcacheKey -Type $Type -Id $Id -Attributes $Attributes
 
     # avoid cache if Force is set
     if(-Not $Force){
         # Testcache first
-        $cacheKey = getcacheKey -Type $Type -Id $Id -Attributes $Attributes
         if(Test-Database -Key $cacheKey){
             return Get-Database -Key $cacheKey
         }


### PR DESCRIPTION
Bug cache not updated properly

repo steps

1. check cache - Country is Angola
2. run get-sfaccount : retreive angola
3. run get-sfacount -force : show new value "Spain"
4. run get-sfaccount again and shows old value Angola